### PR TITLE
Fix web buttons in the footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,4 +1,4 @@
-<a href="https://soupault.app"> <img src="/images/powered_by_soupault_88x31.png" alt="powered by soupault" /> </a>
-<a href="https://creativecommons.org/licenses/by-sa/4.0/"> <img src="/images/cc-by-sa.png" alt="creative commons by-sa" /> </a>
+<a href="https://soupault.app"><img src="/images/powered_by_soupault_88x31.png" alt="Powered by Soupault"/></a>
+<a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="license"><img src="/images/cc-by-sa.png" alt="Creative Commons BY-SA"/></a>
 <a href="https://www.buymeacoffee.com/dmbaturin" target="_blank"><img src="/images/buymeacoffee.png" alt="Buy Me A Coffee" style="height: 31px !important;"></a>
-<a href="https://soupault.goatcounter.com"> <img src="/images/goat_counter.png" alt="stats by goatcounter" /> </a>
+<a href="https://soupault.goatcounter.com"><img src="/images/goat_counter.png" alt="Stats by GoatCounter"/></a>


### PR DESCRIPTION
`<a>` tags are sensitive to whitespace, so the link extends beyond the `<img>` when you put a space after `<a>` or before `</a>`. This commit fixes that, plus adds `rel=license` plus capitalises `alt` text because that's been bugging me.