### PR TITLE
’d noun as verb + abbrevations

### DIFF
--- a/site/install.md
+++ b/site/install.md
@@ -13,7 +13,7 @@ The simplest way to start using soupault is to download a prebuilt executable. J
   <dd><soupault-release platform="macos-x86_64" /></dd>
 </dl>
 
-If you want CDNed links for your [CI scripts](/tips-and-tricks/deployment/), you can use [GitHub releases](https://github.com/dmbaturin/soupault/releases) mirror links.
+If you want <abbr title="content delivery network">CDN</abbr>’d links for your [<abbr title="continuous integration">CI</abbr> scripts](/tips-and-tricks/deployment/), you can use [GitHub releases](https://github.com/dmbaturin/soupault/releases) mirror links.
 
 ### Verifying digital signatures
 


### PR DESCRIPTION
The most widely used version of turning a noun into a past tense verb is
using apostrophe + d, “’d”. For extra clarity and accessibility, I added
`<abbr>` tags for CDN and CI as well.

I look up a block and see that definition list, `<dl>`, though and I
think: I wish more (or some) of these docs were in AsciiDoc as it has
built-ins for definition lists, admonitions, and other things I see.