### PR TITLE
Fix: update `index_date_formats` to `date_formats`

### DIFF
--- a/site/blog/soupault-2.6.0-release.md
+++ b/site/blog/soupault-2.6.0-release.md
@@ -17,14 +17,14 @@ It’s a relatively small release with a few bug fixes and one new feature: conf
 ## Configurable entry sorting
 
 Originally, soupault assumed that the index entry sort key field is some kind of a date. You could configure supported date formats using the
-`index_date_formats` option, and it would attempt to parse every value as a date, or resorted to lexicographic comparison if parsing failed.
+`date_formats` option, and it would attempt to parse every value as a date, or resorted to lexicographic comparison if parsing failed.
 
 A lot of websites with auto-generated index pages are blogs, so that assumption wasn’t terribly unreasonable. However, it still was a rather
 inflexible design.
 
 Now there’s a new option: `sort_type` that can have three values: `calendar` (the default), `numeric`, and `lexicographic`.
 
-The `calendar` mode matches the old behaviour: it tries to parse a field value as a date according to supported `index_date_formats`.
+The `calendar` mode matches the old behaviour: it tries to parse a field value as a date according to supported `date_formats`.
 Invalid values are considered "older" than any valid values. Between themselves, invalid values are compared lexicographically.
 
 In the `numeric` mode, soupault will try to parse values as integer numbers. Invalid values are considered "less" than any valid values.

--- a/site/reference-manual.md
+++ b/site/reference-manual.md
@@ -381,7 +381,7 @@ These are the basic settings:
   # There are three supported ways to sort entries.
   #
   # In the "calendar" mode, soupault will try to parse field values as dates
-  # according to the index_date_formats option (see below).
+  # according to the date_formats option (see below).
   #
   # In the "numeric" mode, it will try to parse fields as integers.
   #
@@ -394,7 +394,7 @@ These are the basic settings:
   # Default %F means YYYY-MM-DD
   # Most of the classic UNIX date format specifiers are supported
   # see https://man7.org/linux/man-pages/man1/date.1.html for example.
-  index_date_formats = ["%F"]
+  date_formats = ["%F"]
 
   # By default, soupault will require valid values for "calendar" and "numeric" sorting
   # If a value is invalid, it’s assumed to be "less" than any valid value.


### PR DESCRIPTION
in accordance with the commit: https://github.com/PataphysicalSociety/soupault/commit/eded3d6f610d826fe8f08d6604192034cfb8012d

The following config

```
[index]
index = true
sort_by = "timestamp"
sort_type = "calendar"
sort_descending = true
index_date_formats = ["%F"]
```

fails with error `[ERROR] Option "index_date_formats" is not valid for table "index".`, while the following config

```
[index]
index = true
sort_by = "timestamp"
sort_type = "calendar"
sort_descending = true
date_formats = ["%F"]
```

works.