### PR TITLE
Update reference-manual.md#hooks-save

### DIFF
--- a/site/reference-manual.md
+++ b/site/reference-manual.md
@@ -2816,7 +2816,7 @@ For a trivial example, here’s how to just write the HTML to the default output
 ```toml
 [hooks.save]
   lua_source = '''
-    Sys.write_file(page_source, target_file)
+    Sys.write_file(target_file, page_source)
   '''
 ```
 


### PR DESCRIPTION
The example save hook had the `Sys.write_file` params backwards