### PR TITLE
Tiny typo fix 

### DIFF
--- a/site/reference-manual.md
+++ b/site/reference-manual.md
@@ -1952,7 +1952,7 @@ Adds a new class. If an element has no classes, adds a `class` attribute in the 
 
 ###### <function>HTML.has_class(html_element, class_name)</function>
 
-Returns true is an element has given class.
+Returns true if an element has given class.
 
 ###### <function>HTML.remove_class(html_element, class_name)</function>
 


### PR DESCRIPTION
BEFORE:
[→ ](https://soupault.app/reference-manual/#HTML.has_class)HTML.has_class(html_element, class_name)
Returns true `is` an element has given class.
AFTER:
[→ ](https://soupault.app/reference-manual/#HTML.has_class)HTML.has_class(html_element, class_name)
Returns true `if` an element has given class.
